### PR TITLE
Using adapted config as return of useConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unholster/react-use-config",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.ts",

--- a/src/useConfig.tsx
+++ b/src/useConfig.tsx
@@ -1,10 +1,6 @@
-import React, { ReactNode, createContext, useContext, useEffect, useState } from "react"
+import React, { Context, ReactNode, createContext, useContext, useEffect, useState } from "react"
 
-const ConfigContext = createContext<unknown>({})
-
-export function useConfig<AdaptedConfig = unknown>() {
-  return useContext<AdaptedConfig | unknown>(ConfigContext)
-}
+type GenericConfig<T extends object> = T
 
 interface ConfigProviderProps<Config = object, AdaptedConfig = Config> {
   children: ReactNode
@@ -12,12 +8,21 @@ interface ConfigProviderProps<Config = object, AdaptedConfig = Config> {
   adapter?: (config: Config) => AdaptedConfig
 }
 
-export function ConfigProvider<Config, AdaptedConfig>({
+const ConfigContext = createContext<GenericConfig<object>>({})
+
+export function useConfig<T extends object>() {
+  return useContext<GenericConfig<T>>(ConfigContext as unknown as Context<GenericConfig<T>>)
+}
+
+export function ConfigProvider<
+  Config extends object, 
+  AdaptedConfig extends object = Config
+>({
   children,
   configPath = "config.json",
   adapter,
 }: ConfigProviderProps) {
-  const [config, setConfig] = useState<Config | AdaptedConfig | object>({})
+  const [config, setConfig] = useState<AdaptedConfig>({} as AdaptedConfig)
 
   useEffect(() => {
     fetch(configPath, {
@@ -33,7 +38,7 @@ export function ConfigProvider<Config, AdaptedConfig>({
         setConfig(adaptedData)
       })
       .catch((err) => {
-        setConfig({})
+        setConfig({} as AdaptedConfig)
         console.warn(`Couldn't load config from ${configPath}:\n ${err}`)
       })
   }, [])


### PR DESCRIPTION
Se repara el tipo que retorna useConfig. Antes siempre retornaba del tipo unknown imidiendo conocer el contenido del config facilmente.

# Cómo probar

Instalar en un proyecto y definir un tipo de retorno en el useConfig. Como resultado debiera sugerir el contenido del config. La imagen muestra un ejemplo de implementación para prueba

![image](https://github.com/Unholster/react-use-config/assets/4176886/fe572881-1b05-4997-8c26-45b91e0e0b6c)
